### PR TITLE
fix: iOS Yellow box warning 'requires main queue setup' since it over…

### DIFF
--- a/ios/Classes/RNGosellSdkReactNative.m
+++ b/ios/Classes/RNGosellSdkReactNative.m
@@ -17,6 +17,12 @@
 {
     return dispatch_get_main_queue();
 }
+
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(kareem:(RCTResponseSenderBlock)callback){
 	callback(@[@"kareem info"]);


### PR DESCRIPTION
fix: iOS Yellow box warning 'requires main queue setup' since it