### PR TITLE
Lock the version for TapCardVlidatorKit-iOS

### DIFF
--- a/ios/RNGosellSdkReactNative.podspec
+++ b/ios/RNGosellSdkReactNative.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
   s.public_header_files = 'Classes/**/*.h'
   s.requires_arc = true
   s.dependency 'goSellSDK', '2.3.13'
+  s.dependency 'TapCardVlidatorKit-iOS', '1.0.17'
   s.dependency "React"
   # s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES'}
   # s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }


### PR DESCRIPTION
To fix the issue of fetching unsupported version of TapCardVlidatorKit-iOS

You can go with this solution, or you can upgrade goSellSDK to 2.3.14 but once you do that it will be great if you can add the line I added and put the version as 1.0.18 to prevent this issue from happening again.