### PR TITLE
Downgrade Gradle and SDK versions in Android build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.4.0'
+        classpath 'com.android.tools.build:gradle:7.3.1'
     }
 }
 
@@ -24,10 +24,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 35
+    compileSdkVersion 34
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 35
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
     }
@@ -42,20 +42,8 @@ repositories {
 
 dependencies {
 implementation 'com.facebook.react:react-native:+'
-    implementation 'com.github.Tap-Payments:goSellSDK-AndroidX:3.19.35.1'
+    implementation 'com.github.Tap-Payments:goSellSDK-AndroidX:3.19.35.3'
     implementation 'com.google.code.gson:gson:2.13.1'
-    implementation 'com.google.android.material:material:1.14.0-alpha03'
-    implementation 'com.github.Tap-Payments:TapGLKit-Android:1.19.1'
-    implementation 'com.github.Tap-Payments:TapCardValidator-Android:2.16.2.1'
-    implementation 'com.squareup.okhttp3:logging-interceptor:5.1.0'
-    implementation 'com.squareup.okhttp3:okhttp:5.1.0'
-    implementation 'com.squareup.retrofit2:retrofit:3.0.0'
-    implementation 'com.squareup.retrofit2:converter-gson:3.0.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:5.1.0'
-    implementation 'com.squareup.picasso:picasso:2.71828'
-    implementation 'com.google.android.gms:play-services-wallet:19.4.0'
-    implementation 'jp.wasabeef:blurry:4.0.1'
-    implementation 'io.card:android-sdk:5.5.1'
-    implementation 'com.github.bumptech.glide:glide:4.12.0'
+    implementation 'com.google.android.material:material:1.12.0-alpha03'
 }
   

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip


### PR DESCRIPTION
Revert Gradle plugin to 7.3.1 and wrapper to 7.4, and lower compileSdkVersion and targetSdkVersion to 34. Also update goSellSDK-AndroidX and material dependencies, and remove several unused dependencies from build.gradle.